### PR TITLE
help時のエラーを修正

### DIFF
--- a/bin/jsmigemo-cli.mjs
+++ b/bin/jsmigemo-cli.mjs
@@ -72,7 +72,7 @@ for (let i = 2; i < process.argv.length; i++) {
 }
 if (mode_help) {
     help(prgname);
-    exit(0);
+    process.exit(0);
 }
 
 const buffer = fs.readFileSync(file);


### PR DESCRIPTION
`jsmigemo --help`をしたときに`ReferenceError: exit is not defined`が発生していたので修正しました